### PR TITLE
Allow user to filter empty or full shops

### DIFF
--- a/chestshop-database-bukkit/src/main/java/io/github/md5sha256/chestshopdatabase/gui/dialog/FilterDialog.java
+++ b/chestshop-database-bukkit/src/main/java/io/github/md5sha256/chestshopdatabase/gui/dialog/FilterDialog.java
@@ -87,8 +87,12 @@ public class FilterDialog {
                 }
             }
             findState.setShopTypes(included);
-            findState.setHideEmptyShops(view.getText("show_empty").equals("disabled"));
-            findState.setHideFullShops(view.getText("show_full").equals("disabled"));
+
+            String show_empty = view.getText("show_empty");
+            String show_full = view.getText("show_full");
+            if (show_empty != null) { findState.setHideEmptyShops(show_empty.equals("disabled")); }
+            if (show_full != null) { findState.setHideFullShops(show_full.equals("disabled")); }
+
             audience.showDialog(prevDialog.get());
         };
     }


### PR DESCRIPTION
Seeing as we now no longer do this by default, if users use the "advanced filtering" options they should be able to specify whether or not they want to see empty or full shops.